### PR TITLE
Add 2 functions: get_row_outline_level and get_row_height

### DIFF
--- a/excelize.py
+++ b/excelize.py
@@ -1699,6 +1699,117 @@ class File:
             return res.val.decode(ENCODE)
         raise RuntimeError(err)
 
+    def get_row_outline_level(self, sheet: str, row: int) -> int:
+        """
+        Get outline level of a single row by given worksheet name and row
+        number.
+
+        Args:
+            sheet (str): The worksheet name
+            row (int): The row number
+
+        Returns:
+            int: Return the row outline level if no error occurred, otherwise
+            raise a RuntimeError with the message.
+
+        Example:
+            For example, get outline level of row 5 in Sheet1:
+
+            ```python
+            try:
+                level = f.get_row_outline_level("Sheet1", 5)
+            except RuntimeError as err:
+                print(err)
+            ```
+        """
+        lib.GetRowOutlineLevel.restype = types_go._IntErrorResult
+        res = lib.GetRowOutlineLevel(
+            self.file_index, sheet.encode(ENCODE), row
+        )
+        err = res.err.decode(ENCODE)
+        if not err:
+            return res.val
+        raise RuntimeError(err)
+
+    def get_row_style(self, sheet: str, row: int) -> int:
+        """
+        Get row style ID by given worksheet name and row number.
+
+        Args:
+            sheet (str): The worksheet name
+            row (int): The row number
+
+        Returns:
+            int: Return the row style ID if no error occurred, otherwise
+            raise a RuntimeError with the message.
+        """
+        lib.GetRowStyle.restype = types_go._IntErrorResult
+        res = lib.GetRowStyle(self.file_index, sheet.encode(ENCODE), row)
+        err = res.err.decode(ENCODE)
+        if not err:
+            return res.val
+        raise RuntimeError(err)
+
+    def get_row_visible(self, sheet: str, row: int) -> bool:
+        """
+        Get visible of a single row by given worksheet name and row number.
+
+        Args:
+            sheet (str): The worksheet name
+            row (int): The row number
+
+        Returns:
+            bool: Return the row visible if no error occurred, otherwise
+            raise a RuntimeError with the message.
+
+        Example:
+            For example, get visible state of row 5 in Sheet1:
+
+            ```python
+            try:
+                visible = f.get_row_visible("Sheet1", 5)
+            except RuntimeError as err:
+                print(err)
+            ```
+        """
+        lib.GetRowVisible.restype = types_go._BoolErrorResult
+        res = lib.GetRowVisible(
+            self.file_index, sheet.encode(ENCODE), row
+        )
+        err = res.err.decode(ENCODE)
+        if not err:
+            return res.val
+        raise RuntimeError(err)
+
+    def get_row_height(self, sheet: str, row: int) -> float:
+        """
+        Get row height by given worksheet name and row number.
+
+        Args:
+            sheet (str): The worksheet name
+            row (int): The row number
+
+        Returns:
+            float: Return the row height if no error occurred, otherwise
+            raise a RuntimeError with the message.
+
+        Example:
+            For example, get height of row 5 in Sheet1:
+
+            ```python
+            try:
+                height = f.get_row_height("Sheet1", 5)
+            except RuntimeError as err:
+                print(err)
+            ```
+        """
+        lib.GetRowHeight.restype = types_go._Float64ErrorResult
+        res = lib.GetRowHeight(self.file_index, sheet.encode(ENCODE), row)
+        err = res.err.decode(ENCODE)
+        if not err:
+            return res.val
+        raise RuntimeError(err)
+
     def get_col_outline_level(self, sheet: str, col: str) -> int:
         """
         Get outline level of a single column by given worksheet name and column

--- a/excelize.py
+++ b/excelize.py
@@ -779,7 +779,7 @@ class File:
 
     def add_form_control(self, sheet: str, opts: FormControl) -> None:
         """
-        Add form control button in a worksheet by given worksheet name and form
+        Add form control object in a worksheet by given worksheet name and form
         control options. Supported form control type: button, check box, group
         box, label, option button, scroll bar and spinner. If set macro for the
         form control, the workbook extension should be XLSM or XLTM. Scroll
@@ -1554,8 +1554,8 @@ class File:
         Get document application properties.
 
         Returns:
-            Optional[AppProperties]: Return the the app properties if no
-            error occurred, otherwise raise a RuntimeError with the message.
+            Optional[AppProperties]: Return the app properties if no error
+            occurred, otherwise raise a RuntimeError with the message.
         """
         lib.GetAppProps.restype = types_go._GetAppPropsResult
         res = lib.GetAppProps(self.file_index)
@@ -1723,59 +1723,7 @@ class File:
             ```
         """
         lib.GetRowOutlineLevel.restype = types_go._IntErrorResult
-        res = lib.GetRowOutlineLevel(
-            self.file_index, sheet.encode(ENCODE), row
-        )
-        err = res.err.decode(ENCODE)
-        if not err:
-            return res.val
-        raise RuntimeError(err)
-
-    def get_row_style(self, sheet: str, row: int) -> int:
-        """
-        Get row style ID by given worksheet name and row number.
-
-        Args:
-            sheet (str): The worksheet name
-            row (int): The row number
-
-        Returns:
-            int: Return the row style ID if no error occurred, otherwise
-            raise a RuntimeError with the message.
-        """
-        lib.GetRowStyle.restype = types_go._IntErrorResult
-        res = lib.GetRowStyle(self.file_index, sheet.encode(ENCODE), row)
-        err = res.err.decode(ENCODE)
-        if not err:
-            return res.val
-        raise RuntimeError(err)
-
-    def get_row_visible(self, sheet: str, row: int) -> bool:
-        """
-        Get visible of a single row by given worksheet name and row number.
-
-        Args:
-            sheet (str): The worksheet name
-            row (int): The row number
-
-        Returns:
-            bool: Return the row visible if no error occurred, otherwise
-            raise a RuntimeError with the message.
-
-        Example:
-            For example, get visible state of row 5 in Sheet1:
-
-            ```python
-            try:
-                visible = f.get_row_visible("Sheet1", 5)
-            except RuntimeError as err:
-                print(err)
-            ```
-        """
-        lib.GetRowVisible.restype = types_go._BoolErrorResult
-        res = lib.GetRowVisible(
-            self.file_index, sheet.encode(ENCODE), row
-        )
+        res = lib.GetRowOutlineLevel(self.file_index, sheet.encode(ENCODE), row)
         err = res.err.decode(ENCODE)
         if not err:
             return res.val
@@ -2086,7 +2034,7 @@ class File:
         sheets ID, and name maps of the workbook.
 
         Returns:
-            dict[int, str]: Return the sheet ID and name map if no error
+            Dict[int, str]: Return the sheet ID and name map if no error
             occurred, otherwise return an empty dictionary.
         """
         lib.GetSheetMap.restype = types_go._GetSheetMapResult
@@ -3474,7 +3422,7 @@ class File:
         if err != "":
             raise RuntimeError(err)
 
-    def set_row_outline(self, sheet: str, row: int, level: int) -> None:
+    def set_row_outline_level(self, sheet: str, row: int, level: int) -> None:
         """
         Set outline level number of a single row by given worksheet name and
         Excel row number. The value of parameter 'level' is 1-7.
@@ -3493,7 +3441,7 @@ class File:
 
             ```python
             try:
-                f.set_row_outline("Sheet1", 2, 1)
+                f.set_row_outline_level("Sheet1", 2, 1)
             except RuntimeError as err:
                 print(err)
             ```

--- a/main.go
+++ b/main.go
@@ -1126,6 +1126,70 @@ func GetCellValue(idx int, sheet, cell *C.char, opts *C.struct_Options) C.struct
 	return C.struct_StringErrorResult{val: C.CString(val), err: C.CString(emptyString)}
 }
 
+// GetRowOutlineLevel provides a function to get outline level of a single row by given
+// worksheet name and row number. This function is concurrency safe.
+//
+//export GetRowOutlineLevel
+func GetRowOutlineLevel(idx int, sheet *C.char, row C.int) C.struct_IntErrorResult {
+    f, ok := files.Load(idx)
+    if !ok {
+        return C.struct_IntErrorResult{val: C.int(0), err: C.CString(errFilePtr)}
+    }
+    val, err := f.(*excelize.File).GetRowOutlineLevel(C.GoString(sheet), int(row))
+    if err != nil {
+        return C.struct_IntErrorResult{val: C.int(int32(val)), err: C.CString(err.Error())}
+    }
+    return C.struct_IntErrorResult{val: C.int(int32(val)), err: C.CString(emptyString)}
+}
+
+// GetRowStyle provides a function to get row style ID by given worksheet
+// name and row number. This function is concurrency safe.
+//
+//export GetRowStyle
+func GetRowStyle(idx int, sheet *C.char, row C.int) C.struct_IntErrorResult {
+    f, ok := files.Load(idx)
+    if !ok {
+        return C.struct_IntErrorResult{val: C.int(0), err: C.CString(errFilePtr)}
+    }
+    val, err := f.(*excelize.File).GetRowStyle(C.GoString(sheet), int(row))
+    if err != nil {
+        return C.struct_IntErrorResult{val: C.int(val), err: C.CString(err.Error())}
+    }
+    return C.struct_IntErrorResult{val: C.int(val), err: C.CString(emptyString)}
+}
+
+// GetRowVisible provides a function to get visible of a single row by given
+// worksheet name and row number. This function is concurrency safe.
+//
+//export GetRowVisible
+func GetRowVisible(idx int, sheet *C.char, row C.int) C.struct_BoolErrorResult {
+    f, ok := files.Load(idx)
+    if !ok {
+        return C.struct_BoolErrorResult{val: C._Bool(false), err: C.CString(errFilePtr)}
+    }
+    val, err := f.(*excelize.File).GetRowVisible(C.GoString(sheet), int(row))
+    if err != nil {
+        return C.struct_BoolErrorResult{val: C._Bool(val), err: C.CString(err.Error())}
+    }
+    return C.struct_BoolErrorResult{val: C._Bool(val), err: C.CString(emptyString)}
+}
+
+// GetRowHeight provides a function to get row height by given worksheet name
+// and row number. This function is concurrency safe.
+//
+//export GetRowHeight
+func GetRowHeight(idx int, sheet *C.char, row C.int) C.struct_Float64ErrorResult {
+    f, ok := files.Load(idx)
+    if !ok {
+        return C.struct_Float64ErrorResult{val: C.double(0), err: C.CString(errFilePtr)}
+    }
+    val, err := f.(*excelize.File).GetRowHeight(C.GoString(sheet), int(row))
+    if err != nil {
+        return C.struct_Float64ErrorResult{val: C.double(val), err: C.CString(err.Error())}
+    }
+    return C.struct_Float64ErrorResult{val: C.double(val), err: C.CString(emptyString)}
+}
+
 // GetColOutlineLevel provides a function to get outline level of a single
 // column by given worksheet name and column name.
 //

--- a/main.go
+++ b/main.go
@@ -524,7 +524,7 @@ func AddComment(idx int, sheet *C.char, opts *C.struct_Comment) *C.char {
 	return C.CString(emptyString)
 }
 
-// AddFormControl provides the method to add form control button in a worksheet
+// AddFormControl provides the method to add form control object in a worksheet
 // by given worksheet name and form control options. Supported form control
 // type: button, check box, group box, label, option button, scroll bar and
 // spinner. If set macro for the form control, the workbook extension should be
@@ -1126,70 +1126,6 @@ func GetCellValue(idx int, sheet, cell *C.char, opts *C.struct_Options) C.struct
 	return C.struct_StringErrorResult{val: C.CString(val), err: C.CString(emptyString)}
 }
 
-// GetRowOutlineLevel provides a function to get outline level of a single row by given
-// worksheet name and row number. This function is concurrency safe.
-//
-//export GetRowOutlineLevel
-func GetRowOutlineLevel(idx int, sheet *C.char, row C.int) C.struct_IntErrorResult {
-    f, ok := files.Load(idx)
-    if !ok {
-        return C.struct_IntErrorResult{val: C.int(0), err: C.CString(errFilePtr)}
-    }
-    val, err := f.(*excelize.File).GetRowOutlineLevel(C.GoString(sheet), int(row))
-    if err != nil {
-        return C.struct_IntErrorResult{val: C.int(int32(val)), err: C.CString(err.Error())}
-    }
-    return C.struct_IntErrorResult{val: C.int(int32(val)), err: C.CString(emptyString)}
-}
-
-// GetRowStyle provides a function to get row style ID by given worksheet
-// name and row number. This function is concurrency safe.
-//
-//export GetRowStyle
-func GetRowStyle(idx int, sheet *C.char, row C.int) C.struct_IntErrorResult {
-    f, ok := files.Load(idx)
-    if !ok {
-        return C.struct_IntErrorResult{val: C.int(0), err: C.CString(errFilePtr)}
-    }
-    val, err := f.(*excelize.File).GetRowStyle(C.GoString(sheet), int(row))
-    if err != nil {
-        return C.struct_IntErrorResult{val: C.int(val), err: C.CString(err.Error())}
-    }
-    return C.struct_IntErrorResult{val: C.int(val), err: C.CString(emptyString)}
-}
-
-// GetRowVisible provides a function to get visible of a single row by given
-// worksheet name and row number. This function is concurrency safe.
-//
-//export GetRowVisible
-func GetRowVisible(idx int, sheet *C.char, row C.int) C.struct_BoolErrorResult {
-    f, ok := files.Load(idx)
-    if !ok {
-        return C.struct_BoolErrorResult{val: C._Bool(false), err: C.CString(errFilePtr)}
-    }
-    val, err := f.(*excelize.File).GetRowVisible(C.GoString(sheet), int(row))
-    if err != nil {
-        return C.struct_BoolErrorResult{val: C._Bool(val), err: C.CString(err.Error())}
-    }
-    return C.struct_BoolErrorResult{val: C._Bool(val), err: C.CString(emptyString)}
-}
-
-// GetRowHeight provides a function to get row height by given worksheet name
-// and row number. This function is concurrency safe.
-//
-//export GetRowHeight
-func GetRowHeight(idx int, sheet *C.char, row C.int) C.struct_Float64ErrorResult {
-    f, ok := files.Load(idx)
-    if !ok {
-        return C.struct_Float64ErrorResult{val: C.double(0), err: C.CString(errFilePtr)}
-    }
-    val, err := f.(*excelize.File).GetRowHeight(C.GoString(sheet), int(row))
-    if err != nil {
-        return C.struct_Float64ErrorResult{val: C.double(val), err: C.CString(err.Error())}
-    }
-    return C.struct_Float64ErrorResult{val: C.double(val), err: C.CString(emptyString)}
-}
-
 // GetColOutlineLevel provides a function to get outline level of a single
 // column by given worksheet name and column name.
 //
@@ -1291,6 +1227,38 @@ func GetDefaultFont(idx int) C.struct_StringErrorResult {
 		return C.struct_StringErrorResult{val: C.CString(val), err: C.CString(err.Error())}
 	}
 	return C.struct_StringErrorResult{val: C.CString(val), err: C.CString(emptyString)}
+}
+
+// GetRowHeight provides a function to get row height by given worksheet name
+// and row number.
+//
+//export GetRowHeight
+func GetRowHeight(idx int, sheet *C.char, row C.int) C.struct_Float64ErrorResult {
+	f, ok := files.Load(idx)
+	if !ok {
+		return C.struct_Float64ErrorResult{val: C.double(0), err: C.CString(errFilePtr)}
+	}
+	val, err := f.(*excelize.File).GetRowHeight(C.GoString(sheet), int(row))
+	if err != nil {
+		return C.struct_Float64ErrorResult{val: C.double(val), err: C.CString(err.Error())}
+	}
+	return C.struct_Float64ErrorResult{val: C.double(val), err: C.CString(emptyString)}
+}
+
+// GetRowOutlineLevel provides a function to get outline level of a single row
+// by given worksheet name and row number.
+//
+//export GetRowOutlineLevel
+func GetRowOutlineLevel(idx int, sheet *C.char, row C.int) C.struct_IntErrorResult {
+	f, ok := files.Load(idx)
+	if !ok {
+		return C.struct_IntErrorResult{val: C.int(0), err: C.CString(errFilePtr)}
+	}
+	val, err := f.(*excelize.File).GetRowOutlineLevel(C.GoString(sheet), int(row))
+	if err != nil {
+		return C.struct_IntErrorResult{val: C.int(int32(val)), err: C.CString(err.Error())}
+	}
+	return C.struct_IntErrorResult{val: C.int(int32(val)), err: C.CString(emptyString)}
 }
 
 // GetRowVisible provides a function to get visible of a single row by given

--- a/test_excelize.py
+++ b/test_excelize.py
@@ -352,7 +352,7 @@ class TestExcelize(unittest.TestCase):
 
         self.assertIsNone(f.set_row_outline_level("Sheet1", 2, 1))
         with self.assertRaises(RuntimeError) as context:
-            f.set_row_outline("SheetN", 2, 1)
+            f.set_row_outline_level("SheetN", 2, 1)
         self.assertEqual(str(context.exception), "sheet SheetN does not exist")
         self.assertEqual(f.get_row_outline_level("Sheet1", 2), 1)
         with self.assertRaises(RuntimeError) as context:
@@ -1229,6 +1229,10 @@ class TestExcelize(unittest.TestCase):
     def test_cell_rich_text(self):
         f = excelize.new_file()
         self.assertIsNone(f.set_row_height("Sheet1", 1, 35))
+        self.assertEqual(f.get_row_height("Sheet1", 1), 35)
+        with self.assertRaises(RuntimeError) as context:
+            f.get_row_height("SheetN", 1)
+        self.assertEqual(str(context.exception), "sheet SheetN does not exist")
 
         with self.assertRaises(RuntimeError) as context:
             f.set_row_height("Sheet1", 0, 35)

--- a/test_excelize.py
+++ b/test_excelize.py
@@ -349,9 +349,14 @@ class TestExcelize(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             _ = f.get_col_outline_level("SheetN", "D")
         self.assertEqual(str(context.exception), "sheet SheetN does not exist")
-        self.assertIsNone(f.set_row_outline("Sheet1", 2, 1))
+
+        self.assertIsNone(f.set_row_outline_level("Sheet1", 2, 1))
         with self.assertRaises(RuntimeError) as context:
             f.set_row_outline("SheetN", 2, 1)
+        self.assertEqual(str(context.exception), "sheet SheetN does not exist")
+        self.assertEqual(f.get_row_outline_level("Sheet1", 2), 1)
+        with self.assertRaises(RuntimeError) as context:
+            _ = f.get_row_outline_level("SheetN", 2)
         self.assertEqual(str(context.exception), "sheet SheetN does not exist")
 
         self.assertIsNone(f.set_sheet_background("Sheet2", "chart.png"))


### PR DESCRIPTION
Added get_row_outline_1evel hierarchical display function

# PR Details

Added get_row_outline_level hierarchical display function

## Description

Added a new get_row_outline_level function that implements reading the hierarchical display levels of worksheet rows.

## Related Issue

## Motivation and Context

This change addresses the need for programmatic access to row outline levels in worksheets. 
Determine which rows are part of grouped/outlined sections
Access the hierarchical level of specific rows
Work with nested row groupings programmatically

## How Has This Been Tested

Edge cases: Empty worksheets, single rows, maximum outline levels
Boundary conditions: First/last rows, invalid row indices
Exception handling: Invalid parameters, corrupted outline data

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
