### PR TITLE
Add new function: set_app_props

### DIFF
--- a/excelize.py
+++ b/excelize.py
@@ -4009,6 +4009,27 @@ class File:
         if err != "":
             raise RuntimeError(err)
 
+    def set_app_props(self, app_properties: AppProperties) -> None:
+        """
+        Set document application properties.
+
+        Args:
+            app_properties (AppProperties): The application properties
+
+        Returns:
+            None: Return None if no error occurred, otherwise raise a
+            RuntimeError with the message.
+        """
+        prepare_args(
+            [app_properties],
+            [argsRule("app_properties", [AppProperties])],
+        )
+        lib.SetAppProps.restype = c_char_p
+        options = py_value_to_c(app_properties, types_go._AppProperties())
+        err = lib.SetAppProps(self.file_index, byref(options)).decode(ENCODE)
+        if err != "":
+            raise RuntimeError(err)
+
     def set_cell_bool(self, sheet: str, cell: str, value: bool) -> None:
         """
         Set bool type value of a cell by given worksheet name, cell reference

--- a/excelize.py
+++ b/excelize.py
@@ -4011,7 +4011,38 @@ class File:
 
     def set_app_props(self, app_properties: AppProperties) -> None:
         """
-        Set document application properties.
+        Set document application properties. The properties that can be set are:
+
+        application: The name of the application that created this document.
+
+        scale_crop: Indicates the display mode of the document thumbnail. Set
+        this element to `true` to enable scaling of the document thumbnail to
+        the display. Set this element to `false` to enable cropping of the
+        document thumbnail to show only sections that will fit the display.
+
+        doc_security: Security level of a document as a numeric value. Document
+        security is defined as:
+            1 - Document is password protected.
+            2 - Document is recommended to be opened as read-only.
+            3 - Document is enforced to be opened as read-only.
+            4 - Document is locked for annotation.
+
+        company: The name of a company associated with the document.
+
+        links_up_to_date: Indicates whether hyperlinks in a document are
+        up-to-date. Set this element to `true` to indicate that hyperlinks are
+        updated. Set this element to `false` to indicate that hyperlinks are
+        outdated.
+
+        hyperlinks_changed: Specifies that one or more hyperlinks in this part
+        were updated exclusively in this part by a producer. The next producer
+        to open this document shall update the hyperlink relationships with the
+        new hyperlinks specified in this part.
+
+        app_version: Specifies the version of the application which produced
+        this document. The content of this element shall be of the form XX.YYYY
+        where X and Y represent numerical values, or the document shall be
+        considered non-conformant.
 
         Args:
             app_properties (AppProperties): The application properties
@@ -4019,6 +4050,26 @@ class File:
         Returns:
             None: Return None if no error occurred, otherwise raise a
             RuntimeError with the message.
+
+        Example:
+            For example:
+
+            ```python
+            try:
+                f.set_app_props(
+                    excelize.AppProperties(
+                        application: "Microsoft Excel",
+                        scale_crop: true,
+                        doc_security: 3,
+                        company: "Company Name",
+                        links_up_to_date: true,
+                        hyperlinks_changed: true,
+                        app_version: "16.0000",
+                    )
+                )
+            except (RuntimeError, TypeError) as err:
+                print(err)
+            ```
         """
         prepare_args(
             [app_properties],

--- a/main.go
+++ b/main.go
@@ -2091,6 +2091,25 @@ func SetActiveSheet(idx, index int) *C.char {
 	return C.CString(emptyString)
 }
 
+// SetAppProps provides a function to set document application properties.
+//
+//export SetAppProps
+func SetAppProps(idx int, opts *C.struct_AppProperties) *C.char {
+	f, ok := files.Load(idx)
+	if !ok {
+		return C.CString(errFilePtr)
+	}
+	goVal, err := cValueToGo(reflect.ValueOf(*opts), reflect.TypeOf(excelize.AppProperties{}))
+	if err != nil {
+		return C.CString(err.Error())
+	}
+	appProps := goVal.Elem().Interface().(excelize.AppProperties)
+	if err := f.(*excelize.File).SetAppProps(&appProps); err != nil {
+		return C.CString(err.Error())
+	}
+	return C.CString(emptyString)
+}
+
 // SetCellBool provides a function to set bool type value of a cell by given
 // worksheet name, cell reference and cell value.
 //

--- a/test_excelize.py
+++ b/test_excelize.py
@@ -80,24 +80,18 @@ class TestExcelize(unittest.TestCase):
             str(context.exception),
             "expected type str for argument 'filename', but got int",
         )
-   
+
     def test_app_props(self):
         f = excelize.new_file()
         expected = excelize.AppProperties(
             application="excelize-py",
-            scale_crop=False,
-            doc_security=0,
             company="Excelize",
-            links_up_to_date=False,
-            hyperlinks_changed=False,
             app_version="1.0.0",
-    )
+        )
         self.assertIsNone(f.set_app_props(expected))
         self.assertEqual(f.get_app_props(), expected)
         self.assertIsNone(f.save_as(os.path.join("test", "TestAppProps.xlsx")))
         self.assertIsNone(f.close())
-        with self.assertRaises(RuntimeError):
-            f.set_app_props(expected)
 
     def test_default_font(self):
         f = excelize.new_file()
@@ -898,6 +892,15 @@ class TestExcelize(unittest.TestCase):
             str(context.exception),
             "expected type int for argument 'index', but got str",
         )
+        with self.assertRaises(RuntimeError) as context:
+            f.set_app_props(excelize.AppProperties())
+        self.assertEqual(str(context.exception), expected)
+        with self.assertRaises(TypeError) as context:
+            f.set_app_props(0)
+        self.assertEqual(
+            str(context.exception),
+            "expected type AppProperties for argument 'app_properties', but got int",
+        )       
         with self.assertRaises(RuntimeError) as context:
             f.set_default_font("")
         self.assertEqual(str(context.exception), expected)

--- a/test_excelize.py
+++ b/test_excelize.py
@@ -96,6 +96,8 @@ class TestExcelize(unittest.TestCase):
         self.assertEqual(f.get_app_props(), expected)
         self.assertIsNone(f.save_as(os.path.join("test", "TestAppProps.xlsx")))
         self.assertIsNone(f.close())
+        with self.assertRaises(RuntimeError):
+            f.set_app_props(expected)
 
     def test_default_font(self):
         f = excelize.new_file()

--- a/test_excelize.py
+++ b/test_excelize.py
@@ -80,11 +80,22 @@ class TestExcelize(unittest.TestCase):
             str(context.exception),
             "expected type str for argument 'filename', but got int",
         )
-
+   
     def test_app_props(self):
         f = excelize.new_file()
-        props = f.get_app_props()
-        self.assertEqual(props.application, "Go Excelize")
+        expected = excelize.AppProperties(
+            application="excelize-py",
+            scale_crop=False,
+            doc_security=0,
+            company="Excelize",
+            links_up_to_date=False,
+            hyperlinks_changed=False,
+            app_version="1.0.0",
+    )
+        self.assertIsNone(f.set_app_props(expected))
+        self.assertEqual(f.get_app_props(), expected)
+        self.assertIsNone(f.save_as(os.path.join("test", "TestAppProps.xlsx")))
+        self.assertIsNone(f.close())
 
     def test_default_font(self):
         f = excelize.new_file()


### PR DESCRIPTION
# PR Details

This PR add a new function set_app_props for setting application properties.

## Description

Go: Added SetAppProps export in main.go
Python: Added set_app_props method in excelize.py
Tests: Added test_app_props in test_excelize.py

## Related Issue

N/A

## Motivation and Context

SetAppProps function was missing.

## How Has This Been Tested

Ran Python unit tests with coverage
Test Round-trip set_app_props and get_app_props
Error path raises RuntimeError for invalid input

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
